### PR TITLE
Remove "sModel" var in error message. (was a copy paste typo)

### DIFF
--- a/gphotofs.c
+++ b/gphotofs.c
@@ -889,7 +889,7 @@ gphotofs_connect()
 
         if (nrofsifs == 0) {
             ret = GP_ERROR_IO_USB_FIND;
-            g_fprintf(stderr, _("Could not retrieve device storage. Make sure that the device %s is unlocked."), sModel);
+            g_fprintf(stderr, _("Could not retrieve device storage. Make sure that your device is unlocked."));
             g_fprintf(stderr, "\n");
             break;
         }


### PR DESCRIPTION
In this context, most of the time it has no sense to have the "smodel" in the error message.
It was just still there because of a copy paste typo in my previous commit.